### PR TITLE
Proposition for testing expiration id token work with logout idp

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractBrokerLogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractBrokerLogoutTest.java
@@ -1,0 +1,41 @@
+package org.keycloak.testsuite.broker;
+
+import org.junit.Before;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.representations.idm.UserRepresentation;
+
+import static org.keycloak.testsuite.admin.ApiUtil.createUserWithAdminClient;
+import static org.keycloak.testsuite.admin.ApiUtil.resetUserPassword;
+
+public abstract class AbstractBrokerLogoutTest extends AbstractBaseBrokerTest {
+
+    @Before
+    public void createUser() {
+        log.debug("creating user for realm " + bc.providerRealmName());
+
+        final UserRepresentation user = new UserRepresentation();
+        user.setUsername(bc.getUserLogin());
+        user.setEmail(bc.getUserEmail());
+        user.setEmailVerified(true);
+        user.setEnabled(true);
+
+        final RealmResource realmResource = adminClient.realm(bc.providerRealmName());
+        final String userId = createUserWithAdminClient(realmResource, user);
+
+        resetUserPassword(realmResource.users().get(userId), bc.getUserPassword(), false);
+    }
+
+    @Before
+    public void addIdentityProviderToProviderRealm() {
+        log.debug("adding identity provider to realm " + bc.consumerRealmName());
+
+        final RealmResource realm = adminClient.realm(bc.consumerRealmName());
+        realm.identityProviders().create(bc.setUpIdentityProvider()).close();
+    }
+
+    @Before
+    public void addClients() {
+        addClientsToProviderAndConsumer();
+    }
+
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerLogoutNoBackChannelTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerLogoutNoBackChannelTest.java
@@ -1,0 +1,84 @@
+package org.keycloak.testsuite.broker;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.keycloak.OAuth2Constants;
+import org.keycloak.TokenVerifier;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.common.VerificationException;
+import org.keycloak.models.IdentityProviderSyncMode;
+import org.keycloak.representations.IDToken;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.services.managers.AuthenticationManager;
+import org.keycloak.services.util.CookieHelper;
+import org.keycloak.testsuite.AssertEvents;
+import org.keycloak.testsuite.util.OAuthClient;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.keycloak.testsuite.admin.ApiUtil.createUserWithAdminClient;
+import static org.keycloak.testsuite.admin.ApiUtil.resetUserPassword;
+import static org.keycloak.testsuite.broker.BrokerTestConstants.REALM_CONS_NAME;
+import static org.keycloak.testsuite.broker.BrokerTestConstants.REALM_PROV_NAME;
+import static org.keycloak.testsuite.broker.BrokerTestTools.getConsumerRoot;
+import static org.keycloak.testsuite.broker.BrokerTestTools.getProviderRoot;
+import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPage;
+
+public class KcOidcBrokerLogoutNoBackChannelTest extends AbstractBrokerLogoutTest {
+    @Rule public AssertEvents events = new AssertEvents(this);
+
+    @Override
+    protected BrokerConfiguration getBrokerConfiguration() {
+        return new KcOidcBrokerLogoutNoBackChannelTest.KcOidcBrokerConfigurationWithoutBackchannel();
+    }
+
+    private static class KcOidcBrokerConfigurationWithoutBackchannel
+        extends KcOidcBrokerConfiguration {
+
+        @Override
+        protected void applyDefaultConfiguration(
+            Map<String, String> config, IdentityProviderSyncMode syncMode) {
+            super.applyDefaultConfiguration(config, syncMode);
+            config.put("backchannelSupported", "false");
+        }
+    }
+
+    @Test
+    public void logoutWithExpiredIdTokenSendsIdTokenHintToIdpWithoutBackChannel() throws VerificationException {
+        driver.navigate().to(getLoginUrl(getConsumerRoot(), bc.consumerRealmName(), "broker-app"));
+        logInWithBroker(bc);
+        updateAccountInformation();
+
+        // Exchange code from "broker-app" client of "consumer" realm for the tokens
+        String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
+        OAuthClient.AccessTokenResponse response =
+            oauth
+                .realm(bc.consumerRealmName())
+                .clientId("broker-app")
+                .redirectUri(getConsumerRoot() + "/auth/realms/" + REALM_CONS_NAME + "/app")
+                .doAccessTokenRequest(code, "broker-app-secret");
+        assertEquals(200, response.getStatusCode());
+
+        String idTokenString = response.getIdToken();
+        IDToken idToken = TokenVerifier.create(idTokenString, IDToken.class).getToken();
+        int expiresInMs = (int) (idToken.getExp() - idToken.getIat());
+
+        // simulate token expiration
+        setTimeOffset(expiresInMs * 2);
+
+        // logout with passing id_token_hint
+        logoutFromRealm(
+            getConsumerRoot(),
+            bc.consumerRealmName(),
+            "something-else",
+            idTokenString,
+            "broker-app",
+            getConsumerRoot() + "/auth/realms/" + REALM_CONS_NAME + "/app");
+
+        // user should be logged out successfully from the IDP even though the id_token_hint is expired
+        driver.navigate().to(getAccountUrl(getProviderRoot(), REALM_PROV_NAME));
+        waitForPage(driver, "sign in to provider", true);
+    }
+}


### PR DESCRIPTION
A friendly proposition from your work to :
- check logout idp backchannel
- check logout idp without backchannel
- keep original config default config on KcOidcBrokerLogoutTest 

:)